### PR TITLE
Fix TypeError when credential type field hint is null

### DIFF
--- a/src/MultiFlexi/CredentialType.php
+++ b/src/MultiFlexi/CredentialType.php
@@ -148,7 +148,7 @@ class CredentialType extends DBEngine
 
         foreach ($fielder->listingQuery()->where(['credential_type_id' => $this->getMyKey()]) as $fieldData) {
             $field = new ConfigFieldWithHelper((string) $fieldData['keyname'], $fieldData['type'], $fieldData['keyname'], (string) $fieldData['description']);
-            $field->setHint($fieldData['hint'])->setDefaultValue($fieldData['defval'])->setRequired($fieldData['required'] === 1)->setHelper((string) $fieldData['helper']);
+            $field->setHint((string) $fieldData['hint'])->setDefaultValue($fieldData['defval'])->setRequired($fieldData['required'] === 1)->setHelper((string) $fieldData['helper']);
             $field->setMyKey($fieldData['id']);
 
             if ($this->getPrototype()) {


### PR DESCRIPTION
CredentialType::getFields() passed a nullable hint column straight to ConfigField::setHint(string), throwing a TypeError for any field with a NULL hint. Cast to string, consistent with the keyname/description/ helper casts already on the same line.