### PR TITLE
fix(Job): restore PHP 8.2 compatibility by dropping typed class constants

### DIFF
--- a/src/MultiFlexi/Job.php
+++ b/src/MultiFlexi/Job.php
@@ -27,8 +27,8 @@ use MultiFlexi\Zabbix\Request\Packet as ZabbixPacket;
  */
 class Job extends DBEngine
 {
-    public const string SCHEDULE_TYPE_ADHOC = 'adhoc';
-    public const string SCHEDULE_TYPE_COMMAND_LINE = 'CommandLine';
+    public const SCHEDULE_TYPE_ADHOC = 'adhoc';
+    public const SCHEDULE_TYPE_COMMAND_LINE = 'CommandLine';
 
     public executor $executor;
     public static array $intervalCode = [


### PR DESCRIPTION
## Summary
- Fixes #46
- #45 declared `SCHEDULE_TYPE_ADHOC`/`SCHEDULE_TYPE_COMMAND_LINE` as **typed** class constants (`public const string ...`), which is a PHP 8.3-only feature. This package has no declared PHP version floor and targets distros shipping PHP 8.2 (e.g. Debian bookworm), so it's a fatal parse error there.
- Confirmed in production: after upgrading a bookworm host (PHP 8.2.32) to the build containing #45, `multiflexi-cli` was entirely broken and `multiflexi-scheduler.service` crash-looped until systemd's restart limit kicked in — a full scheduling outage. Verified fixed with the same two-line revert applied manually on that host before submitting this PR.
- Purely mechanical: drops the `: string` type annotation, no behavioral change.

## Test plan
- [x] `php -l` on the changed file
- [x] Manually verified on the affected production host (PHP 8.2.32): applying this exact change and restarting `multiflexi-scheduler` restored it to `active (running)` with `NRestarts=0`.
- [ ] Would be good to add a PHP 8.2 leg to CI so this class of regression can't reach a release again — happy to also add a `"php": ">=8.2"` composer constraint if useful, let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated schedule type constants for broader compatibility.
  * Schedule type values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->