### PR TITLE
Force clone RunTemplates to be created disabled

### DIFF
--- a/src/MultiFlexi/RunTemplate.php
+++ b/src/MultiFlexi/RunTemplate.php
@@ -81,6 +81,58 @@ class RunTemplate extends \MultiFlexi\DBEngine
         return $changed;
     }
 
+    /**
+     * Clone this run template as a new, always-disabled run template.
+     *
+     * The clone is created with active=false regardless of this template's
+     * state, so a copied (and not-yet-reviewed) config can never be picked
+     * up by the scheduler.
+     */
+    public function cloneAs(string $newName): int
+    {
+        $newTemplate = new self();
+
+        $templateData = $this->getData();
+        unset(
+            $templateData[$this->getKeyColumn()],
+            $templateData['last_schedule'],
+            $templateData['next_schedule'],
+            $templateData['failed_jobs_count'],
+            $templateData['successfull_jobs_count'],
+        );
+        $templateData['name'] = $newName;
+        $templateData['active'] = false;
+
+        $newId = $newTemplate->insertToSQL($templateData);
+
+        if ($newId) {
+            $configFields = $this->getRuntemplateEnvironment()->getFields();
+            $newConfigurator = new Configuration([], ['autoload' => false]);
+
+            foreach ($configFields as $field) {
+                $newConfigurator->insertToSQL([
+                    'runtemplate_id' => $newId,
+                    'app_id' => $templateData['app_id'],
+                    'company_id' => $templateData['company_id'],
+                    'name' => $field->getName(),
+                    'value' => $field->getValue(),
+                    'config_type' => $field->getType(),
+                ]);
+            }
+
+            $credHelper = new RunTplCreds();
+
+            foreach ($credHelper->getCredentialsForRuntemplate((int) $this->getMyKey())->fetchAll() as $cred) {
+                $credHelper->insertToSQL([
+                    'runtemplate_id' => $newId,
+                    'credentials_id' => $cred['credentials_id'],
+                ]);
+            }
+        }
+
+        return (int) $newId;
+    }
+
     public function performInit(): void
     {
         $app = new Application((int) $this->getDataValue('app_id'));

--- a/tests/src/MultiFlexi/RunTemplateTest.php
+++ b/tests/src/MultiFlexi/RunTemplateTest.php
@@ -52,6 +52,22 @@ class RunTemplateTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers \MultiFlexi\RunTemplate::cloneAs
+     */
+    public function testcloneAs(): void
+    {
+        // ensure source is active, so we can prove the clone is not
+        $this->object->setDataValue('active', true);
+        $this->object->dbsync();
+
+        $newId = $this->object->cloneAs('Clone Test '.uniqid());
+        $this->assertGreaterThan(0, $newId);
+
+        $clone = new RunTemplate($newId);
+        $this->assertFalse((bool) $clone->getDataValue('active'));
+    }
+
+    /**
      * @covers \MultiFlexi\RunTemplate::performInit
      */
     public function testperformInit(): void


### PR DESCRIPTION
## Summary
- `RunTemplate::cloneAs()` clones a source template's config, saved env values, and credential assignments into a new row, always forcing `active=false` on the clone.
- Previously the clone endpoints copied `active` verbatim from the source, so cloning an active RunTemplate produced another active one that the scheduler could pick up before its (copied, unreviewed) config was checked.
- This method will be reused by `multiflexi-web`, `multiflexi-web5`, and a new `multiflexi-cli run-template:clone` command (companion PRs).

## Test plan
- [x] `php -l` on changed files
- [x] Added `RunTemplateTest::testcloneAs()` asserting the clone is `active=false` even when the source is active (integration test, needs the project's test DB to run)
- [ ] Manual: clone an active RunTemplate via the web UI and confirm the new row is disabled

For SpojeNetIT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to duplicate an existing run template under a new name.
  * Cloned templates retain configuration and assigned credentials but start disabled.
  * Scheduling and identity counters are reset for the new template.

* **Tests**
  * Added coverage verifying successful template duplication and disabled status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->